### PR TITLE
Create matrix for static analysis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,11 +51,17 @@ env:
   matrix:
   - HEADLESS=true
   - HEADLESS=false
+  - STATIC=true
+  - STATIC=false
 
 matrix:
   exclude:
   - os: osx
     env: HEADLESS=true
+  - os: osx
+    env: STATIC=true
+  - env: HEADLESS=false
+    env: STATIC=true
 
 after_success:
   - if [[ "$TRAVIS_OS_NAME" == "linux" && "$HEADLESS" == "false" ]] ; then mvn jacoco:report coveralls:report -U -P travis-coverage ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,19 +49,16 @@ env:
   # see http://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#runOrder for valid values
   - RUN_ORDER=filesystem
   matrix:
-  - HEADLESS=true
-  - HEADLESS=false
-  - STATIC=true
-  - STATIC=false
+  - HEADLESS=true STATIC=true
+  - HEADLESS=true STATIC=false
+  - HEADLESS=false STATIC=false
 
 matrix:
   exclude:
   - os: osx
-    env: HEADLESS=true
+    env: HEADLESS=true STATIC=true
   - os: osx
-    env: STATIC=true
-  - env: HEADLESS=false
-    env: STATIC=true
+    env: HEADLESS=true STATIC=false
 
 after_success:
   - if [[ "$TRAVIS_OS_NAME" == "linux" && "$HEADLESS" == "false" ]] ; then mvn jacoco:report coveralls:report -U -P travis-coverage ; fi

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -12,18 +12,23 @@ HEADLESS=${HEADLESS:-false}
 export MAVEN_OPTS=-Xmx1536m
 
 if [[ "${HEADLESS}" == "true" ]] ; then
-    # compile with ECJ for warnings or errors
-    mvn antrun:run -Danttarget=tests-warnings
-    # run SpotBugs only on headless, failing build if bugs are found
-    # SpotBugs configuration is in pom.xml
-    mvn clean test -U -P travis-spotbugs --batch-mode
-    # run javadoc, headless tests
-    mvn javadoc:javadoc test -U -P travis-headless --batch-mode \
-        -Dsurefire.printSummary=${PRINT_SUMMARY} \
-        -Dsurefire.runOrder=${RUN_ORDER} \
-        -Dant.jvm.args="-Djava.awt.headless=${HEADLESS}" \
-        -Djava.awt.headless=${HEADLESS} \
-        -Dcucumber.options="--tags 'not @Ignore' --tags 'not @firefox'"
+    if [[ "${STATIC}" == "true" ]] ; then
+        # compile with ECJ for warnings or errors
+        mvn antrun:run -Danttarget=tests-warnings
+        # run SpotBugs only on headless, failing build if bugs are found
+        # SpotBugs configuration is in pom.xml
+        mvn clean test -U -P travis-spotbugs --batch-mode
+        # run Javadoc
+        mvn javadoc:javadoc -U --batch-mode
+    else
+        # run headless tests
+        mvn test -U -P travis-headless --batch-mode \
+            -Dsurefire.printSummary=${PRINT_SUMMARY} \
+            -Dsurefire.runOrder=${RUN_ORDER} \
+            -Dant.jvm.args="-Djava.awt.headless=${HEADLESS}" \
+            -Djava.awt.headless=${HEADLESS} \
+            -Dcucumber.options="--tags 'not @Ignore' --tags 'not @firefox'"
+    fi
 else
     # run full GUI test suite and fail on coverage issues
     mvn verify -U -P travis-coverage --batch-mode \


### PR DESCRIPTION
Create a Travis CI matrix to run all static analysis tools in their own Travis CI instance. This is expected to reduce the run time of all Travis CI jobs.